### PR TITLE
fix: WI23 intro cv series metadata typo

### DIFF
--- a/2023/WI23/intro-cv-series/.acm-ai-metadata.yml
+++ b/2023/WI23/intro-cv-series/.acm-ai-metadata.yml
@@ -1,2 +1,2 @@
 title: "Intro to CV Workshop Series"
-description: "This workshop series will teach you the fundamentals of machine leraning and computer vision. We will cover neural networks, CNNs, and more."
+description: "This workshop series will teach you the fundamentals of machine learning and computer vision. We will cover neural networks, CNNs, and more."


### PR DESCRIPTION
- "machine leraning" changed to "machine learning" in WI23 intro cv series metadata